### PR TITLE
tweaked logger warnings

### DIFF
--- a/genome/management/commands/gene_sync.py
+++ b/genome/management/commands/gene_sync.py
@@ -92,7 +92,6 @@ class Command(BaseCommand):
                     'not_curated_rat_genome_database': not_curated_rat_genome_database,
                 }
             )
-            logger.info(created)
 
             # Create GeneSynonym
             synonyms = hgnc_gene_data[
@@ -126,4 +125,3 @@ class Command(BaseCommand):
                     'status': getattr(choices.HGNC_GENE_STATUS, 'ucsc_gene')
                 }
             )
-            logger.info(created)


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ logger will issue WARN level alert when objects are not created and an identifying label to help debug